### PR TITLE
Solution persisted instance name

### DIFF
--- a/modules/core/db/init/hsql/10.create-db.sql
+++ b/modules/core/db/init/hsql/10.create-db.sql
@@ -28,6 +28,7 @@ create table CEEIIN_OWNER (
     DTYPE varchar(31),
     --
     OWNER_IDENTIFICATION_NUMBER varchar(255),
+    DESCRIPTION varchar(255),
     --
     -- from ceeiin_Person
     USER_ID varchar(36),

--- a/modules/core/db/update/hsql/19/190531-2-updateOwner.sql
+++ b/modules/core/db/update/hsql/19/190531-2-updateOwner.sql
@@ -1,0 +1,1 @@
+alter table CEEIIN_OWNER add column DESCRIPTION varchar(255) ;

--- a/modules/core/src/com/rtcab/ceeiin/core/EntityListenerRegisterer.java
+++ b/modules/core/src/com/rtcab/ceeiin/core/EntityListenerRegisterer.java
@@ -1,0 +1,27 @@
+package com.rtcab.ceeiin.core;
+
+import org.springframework.stereotype.Component;
+
+import com.haulmont.cuba.core.global.Events;
+import com.haulmont.cuba.core.sys.events.AppContextInitializedEvent;
+import com.haulmont.cuba.core.sys.listener.EntityListenerManager;
+import com.haulmont.cuba.security.entity.User;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import javax.inject.Inject;
+
+@Component(EntityListenerRegisterer.NAME)
+public class EntityListenerRegisterer {
+    public static final String NAME = "ceeiin_EntityListenerRegisterer";
+
+
+    @Inject
+    private EntityListenerManager entityListenerManager;
+
+    @EventListener(AppContextInitializedEvent.class)
+    @Order(Events.LOWEST_PLATFORM_PRECEDENCE + 100)
+    public void initEntityListeners() {
+        entityListenerManager.addListener(User.class, "ceeiin_PersonInstanceNameUpdaterOnUserChange");
+    }
+}

--- a/modules/core/src/com/rtcab/ceeiin/core/OwnerInstanceNameGenerator.java
+++ b/modules/core/src/com/rtcab/ceeiin/core/OwnerInstanceNameGenerator.java
@@ -1,0 +1,23 @@
+package com.rtcab.ceeiin.core;
+
+import com.haulmont.cuba.core.EntityManager;
+import com.haulmont.cuba.core.listener.BeforeInsertEntityListener;
+import com.haulmont.cuba.core.listener.BeforeUpdateEntityListener;
+import com.rtcab.ceeiin.entity.Owner;
+import org.springframework.stereotype.Component;
+
+@Component(OwnerInstanceNameGenerator.NAME)
+public class OwnerInstanceNameGenerator implements BeforeInsertEntityListener<Owner>,
+        BeforeUpdateEntityListener<Owner> {
+    public static final String NAME = "ceeiin_OwnerInstanceNameGenerator";
+
+    @Override
+    public void onBeforeInsert(Owner entity, EntityManager entityManager) {
+        entity.setDescription(entity.generateInstanceName());
+    }
+
+    @Override
+    public void onBeforeUpdate(Owner entity, EntityManager entityManager) {
+        entity.setDescription(entity.generateInstanceName());
+    }
+}

--- a/modules/core/src/com/rtcab/ceeiin/core/OwnerInstanceNameGenerator.java
+++ b/modules/core/src/com/rtcab/ceeiin/core/OwnerInstanceNameGenerator.java
@@ -7,7 +7,8 @@ import com.rtcab.ceeiin.entity.Owner;
 import org.springframework.stereotype.Component;
 
 @Component(OwnerInstanceNameGenerator.NAME)
-public class OwnerInstanceNameGenerator implements BeforeInsertEntityListener<Owner>,
+public class OwnerInstanceNameGenerator implements
+        BeforeInsertEntityListener<Owner>,
         BeforeUpdateEntityListener<Owner> {
     public static final String NAME = "ceeiin_OwnerInstanceNameGenerator";
 

--- a/modules/core/src/com/rtcab/ceeiin/core/PersonInstanceNameUpdaterOnUserChange.java
+++ b/modules/core/src/com/rtcab/ceeiin/core/PersonInstanceNameUpdaterOnUserChange.java
@@ -1,0 +1,30 @@
+package com.rtcab.ceeiin.core;
+
+import com.haulmont.cuba.core.EntityManager;
+import com.haulmont.cuba.core.TypedQuery;
+import com.haulmont.cuba.core.listener.BeforeInsertEntityListener;
+import com.haulmont.cuba.core.listener.BeforeUpdateEntityListener;
+import com.haulmont.cuba.security.entity.User;
+import com.rtcab.ceeiin.entity.Owner;
+import com.rtcab.ceeiin.entity.Person;
+import org.springframework.stereotype.Component;
+
+@Component(PersonInstanceNameUpdaterOnUserChange.NAME)
+public class PersonInstanceNameUpdaterOnUserChange implements BeforeUpdateEntityListener<User> {
+
+    public static final String NAME = "ceeiin_PersonInstanceNameUpdaterOnUserChange";
+
+    @Override
+    public void onBeforeUpdate(User entity, EntityManager entityManager) {
+
+        TypedQuery<Person> query = entityManager.createQuery("select e from ceeiin_Person e where e.user = :user", Person.class);
+        query.setParameter("user", entity);
+
+        Person person = query.getFirstResult();
+
+        person.setUser(entity);
+        person.setDescription(person.generateInstanceName());
+
+        entityManager.persist(person);
+    }
+}

--- a/modules/global/src/com/rtcab/ceeiin/entity/Company.java
+++ b/modules/global/src/com/rtcab/ceeiin/entity/Company.java
@@ -7,7 +7,6 @@ import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 
 @DiscriminatorValue("COMPANY")
-@NamePattern("%s|name")
 @Entity(name = "ceeiin_Company")
 public class Company extends Owner {
     @Column(name = "NAME")
@@ -19,5 +18,10 @@ public class Company extends Owner {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public String generateInstanceName() {
+        return name;
     }
 }

--- a/modules/global/src/com/rtcab/ceeiin/entity/Owner.java
+++ b/modules/global/src/com/rtcab/ceeiin/entity/Owner.java
@@ -1,6 +1,8 @@
 package com.rtcab.ceeiin.entity;
 
+import com.haulmont.chile.core.annotations.NamePattern;
 import com.haulmont.cuba.core.entity.StandardEntity;
+import com.haulmont.cuba.core.entity.annotation.Listeners;
 
 import javax.persistence.*;
 
@@ -8,10 +10,23 @@ import javax.persistence.*;
 @DiscriminatorColumn(name = "DTYPE", discriminatorType = DiscriminatorType.STRING)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @Table(name = "CEEIIN_OWNER")
+@NamePattern("%s|description")
 @Entity(name = "ceeiin_Owner")
+@Listeners("ceeiin_OwnerInstanceNameGenerator")
 public class Owner extends StandardEntity {
     @Column(name = "OWNER_IDENTIFICATION_NUMBER")
     protected String ownerIdentificationNumber;
+
+    @Column(name = "DESCRIPTION")
+    protected String description;
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
 
     public String getOwnerIdentificationNumber() {
         return ownerIdentificationNumber;
@@ -19,5 +34,9 @@ public class Owner extends StandardEntity {
 
     public void setOwnerIdentificationNumber(String ownerIdentificationNumber) {
         this.ownerIdentificationNumber = ownerIdentificationNumber;
+    }
+
+    public String generateInstanceName() {
+        return "";
     }
 }

--- a/modules/global/src/com/rtcab/ceeiin/entity/Person.java
+++ b/modules/global/src/com/rtcab/ceeiin/entity/Person.java
@@ -1,12 +1,11 @@
 package com.rtcab.ceeiin.entity;
 
-import com.haulmont.chile.core.annotations.NamePattern;
 import com.haulmont.cuba.security.entity.User;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @DiscriminatorValue("PERSON")
-@NamePattern("%s|user")
 @Entity(name = "ceeiin_Person")
 public class Person extends Owner {
     @ManyToOne(fetch = FetchType.LAZY)
@@ -31,5 +30,14 @@ public class Person extends Owner {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    @Override
+    public String generateInstanceName() {
+        return renderAttribute(getPersonId()) + " - " + renderAttribute(user.getCaption());
+    }
+
+    private String renderAttribute(String field) {
+        return Objects.toString(field, "");
     }
 }

--- a/modules/global/src/com/rtcab/ceeiin/entity/messages.properties
+++ b/modules/global/src/com/rtcab/ceeiin/entity/messages.properties
@@ -5,6 +5,7 @@ Person=Person
 Person.personId=Person id
 Owner=Owner
 Owner.ownerIdentificationNumber=Owner identification number
+Owner.description=Description
 Pet.name=Name
 Pet.owner=Owner
 Pet=Pet

--- a/modules/web/src/com/rtcab/ceeiin/web/owner/owner-browse.xml
+++ b/modules/web/src/com/rtcab/ceeiin/web/owner/owner-browse.xml
@@ -35,6 +35,7 @@
             </actions>
             <columns>
                 <column id="ownerIdentificationNumber" />
+                <column id="description" />
             </columns>
             <rowsCount/>
             <buttonsPanel id="buttonsPanel"


### PR DESCRIPTION
This PR solves the problem by defining a persistent attribute in the superclass `Owner` - called `description`.

The description field is updated on every change of the instances and is set accordingly in the subclasses:


### Company.java
```java
public class Company extends Owner {
    @Column(name = "NAME")
    protected String name;

    public String getName() {
        return name;
    }

    public void setName(String name) {
        this.name = name;
    }

    @Override
    public String generateInstanceName() {
        return name;
    }
}
```

### Person.java
```java
public class Person extends Owner {

    @Override
    public String generateInstanceName() {
        return renderAttribute(getPersonId()) + " - " + renderAttribute(user.getCaption());
    }

    private String renderAttribute(String field) {
        return Objects.toString(field, "");
    }
}
```

### Entity Listeners

The entity listeners update the description by calling `generateInstanceName()` on the instance:

```
@Component(OwnerInstanceNameGenerator.NAME)
public class OwnerInstanceNameGenerator implements
        BeforeInsertEntityListener<Owner>,
        BeforeUpdateEntityListener<Owner> {
    public static final String NAME = "ceeiin_OwnerInstanceNameGenerator";

    @Override
    public void onBeforeInsert(Owner entity, EntityManager entityManager) {
        entity.setDescription(entity.generateInstanceName());
    }

    @Override
    public void onBeforeUpdate(Owner entity, EntityManager entityManager) {
        entity.setDescription(entity.generateInstanceName());
    }
}
```